### PR TITLE
Add GitHub Actions workflow to trigger Jenkins job on production push

### DIFF
--- a/.github/workflows/jenkins-trigger-prod.yml
+++ b/.github/workflows/jenkins-trigger-prod.yml
@@ -1,0 +1,29 @@
+name: Trigger Jenkins Job
+
+on:
+  push:
+    branches:
+      - 'production'
+  workflow_dispatch:
+
+jobs:
+  trigger-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Get the branch name and build the URL for Jenkins
+      - name: Get branch name and build Jenkins URL
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
+          JENKINS_URL="https://automation.prms.cgiar.org/job/prms-risk-main/build"
+          echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
+          echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
+        
+      # Step 2: Execute the curl command to trigger the job in Jenkins with the dynamically built URL
+      - name: Trigger Jenkins Job
+        run: |
+          curl -X POST ${{ env.JENKINS_URL }} --user ${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_API_TOKEN }}
+        env:
+          JENKINS_URL: ${{ env.JENKINS_URL }}
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}


### PR DESCRIPTION
- Create a new workflow file to trigger a Jenkins job when code is pushed to the production branch or manually dispatched.
- Include steps to build the Jenkins job URL dynamically and execute a curl command to trigger the job using stored secrets for authentication.