### PR TITLE
Fix bold title wrapping in landscape PDF

### DIFF
--- a/front-end/src/app/Admin/admin-module/exports/exports.component.ts
+++ b/front-end/src/app/Admin/admin-module/exports/exports.component.ts
@@ -147,7 +147,9 @@ export class ExportsComponent {
       const colW = cols[0].w - cellPad * 2;
 
       const riskLayouts: RiskLayout[] = top5.map(risk => {
+        doc.setFont('helvetica', 'bold');
         const titleLines = doc.splitTextToSize(String(risk.title || ''), colW) as string[];
+        doc.setFont('helvetica', 'normal');
         const descText = stripHtml(String(risk.description || ''));
         const descLines = doc.splitTextToSize(descText, colW) as string[];
 

--- a/front-end/src/app/home/risk-management/risk-report/risk-report-table/risk-report-table.component.ts
+++ b/front-end/src/app/home/risk-management/risk-report/risk-report-table/risk-report-table.component.ts
@@ -547,7 +547,9 @@ export class RiskReportTableComponent {
       const colW = cols[0].w - cellPad * 2;
 
       const riskLayouts: RiskLayout[] = top5.map(risk => {
+        doc.setFont('helvetica', 'bold');
         const titleLines = doc.splitTextToSize(String(risk.title || ''), colW) as string[];
+        doc.setFont('helvetica', 'normal');
         const descText = stripHtml(String(risk.description || ''));
         const descLines = doc.splitTextToSize(descText, colW) as string[];
 


### PR DESCRIPTION
- Measure title text width with bold font so splitTextToSize wraps correctly
- Prevents risk titles from overflowing into the actions column