### PR TITLE
Add public Explore page and PDF export improvements

### DIFF
--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -22,6 +22,7 @@ import { FaqModule } from './faq/faq.module';
 import { PhasesModule } from './phases/phases.module';
 import dataSource, { dataSourceOptions } from 'db/data-source';
 import { OrganizationsModule } from './organizations/organizations.module';
+import { ExploreModule } from './explore/explore.module';
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { OrganizationsModule } from './organizations/organizations.module';
     FaqModule,
     PhasesModule,
     OrganizationsModule,
+    ExploreModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/back-end/src/explore/explore.controller.ts
+++ b/back-end/src/explore/explore.controller.ts
@@ -97,9 +97,10 @@ export class ExploreController {
     return results;
   }
 
-  @Get('programs/:official_code')
+  @Get(['programs/:official_code', 'programs/:official_code/:version_id'])
   async getProgramByOfficialCode(
     @Param('official_code') officialCode: string,
+    @Param('version_id') versionId?: string,
   ) {
     const root = await this.programService.programRepository.findOne({
       where: {
@@ -114,32 +115,53 @@ export class ExploreController {
       );
     }
 
-    const latestVersion = await this.programService.programRepository.findOne({
-      where: {
-        parent_id: root.id,
-        status: true,
-      },
-      relations: [
-        'risks',
-        'risks.category',
-        'risks.category.category_group',
-        'risks.mitigations',
-        'risks.mitigations.status',
-        'risks.risk_owner',
-        'risks.risk_owner.user',
-        'phase',
-        'roles',
-        'roles.user',
-      ],
-      order: { id: 'DESC', risks: { top: 'ASC', id: 'DESC' } },
-    });
+    const versionRelations = [
+      'risks',
+      'risks.category',
+      'risks.category.category_group',
+      'risks.mitigations',
+      'risks.mitigations.status',
+      'risks.risk_owner',
+      'risks.risk_owner.user',
+      'phase',
+      'roles',
+      'roles.user',
+    ];
 
-    if (!latestVersion) {
-      throw new NotFoundException(
-        `No submitted version found for program "${officialCode}"`,
-      );
+    let version;
+
+    if (versionId) {
+      version = await this.programService.programRepository.findOne({
+        where: {
+          id: +versionId,
+          parent_id: root.id,
+        },
+        relations: versionRelations,
+        order: { risks: { top: 'ASC', id: 'DESC' } },
+      });
+
+      if (!version) {
+        throw new NotFoundException(
+          `Version ${versionId} not found for program "${officialCode}"`,
+        );
+      }
+    } else {
+      version = await this.programService.programRepository.findOne({
+        where: {
+          parent_id: root.id,
+          status: true,
+        },
+        relations: versionRelations,
+        order: { id: 'DESC', risks: { top: 'ASC', id: 'DESC' } },
+      });
+
+      if (!version) {
+        throw new NotFoundException(
+          `No submitted version found for program "${officialCode}"`,
+        );
+      }
     }
 
-    return latestVersion;
+    return version;
   }
 }

--- a/back-end/src/explore/explore.controller.ts
+++ b/back-end/src/explore/explore.controller.ts
@@ -1,0 +1,145 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ProgramService } from 'src/program/program.service';
+import { ILike, IsNull } from 'typeorm';
+
+@ApiTags('Explore')
+@Controller('explore')
+export class ExploreController {
+  constructor(private readonly programService: ProgramService) {}
+
+  @Get('programs')
+  async getPrograms(@Query('search') search?: string) {
+    const baseWhere = {
+      parent_id: IsNull(),
+      archived: false,
+    };
+
+    const where = search
+      ? [
+          { ...baseWhere, name: ILike(`%${search}%`) },
+          { ...baseWhere, official_code: ILike(`%${search}%`) },
+        ]
+      : baseWhere;
+
+    const rootPrograms = await this.programService.programRepository.find({
+      where,
+      relations: ['organizations', 'risks', 'risks.mitigations'],
+      order: { official_code: 'ASC' },
+    });
+
+    const results = [];
+
+    for (const root of rootPrograms) {
+      const latestSubmitted =
+        await this.programService.programRepository.findOne({
+          where: { parent_id: root.id, status: true },
+          relations: ['phase'],
+          order: { id: 'DESC' },
+        });
+
+      if (!latestSubmitted) continue;
+
+      const risks = root.risks ?? [];
+      const riskCount = risks.length;
+      const avgCurrentLevel =
+        riskCount > 0
+          ? Math.round(
+              (risks.reduce(
+                (sum, r) =>
+                  sum +
+                  (r.current_level ??
+                    (r.current_likelihood ?? 0) * (r.current_impact ?? 0)),
+                0,
+              ) /
+                riskCount) *
+                100,
+            ) / 100
+          : 0;
+      const avgTargetLevel =
+        riskCount > 0
+          ? Math.round(
+              (risks.reduce(
+                (sum, r) =>
+                  sum +
+                  (r.target_level ??
+                    (r.target_likelihood ?? 0) * (r.target_impact ?? 0)),
+                0,
+              ) /
+                riskCount) *
+                100,
+            ) / 100
+          : 0;
+
+      const totalActions = risks.reduce(
+        (sum, r) => sum + (r.mitigations?.length ?? 0),
+        0,
+      );
+
+      results.push({
+        id: root.id,
+        official_code: root.official_code,
+        name: root.name,
+        organizations: root.organizations,
+        risk_count: riskCount,
+        total_actions: totalActions,
+        avg_current_level: avgCurrentLevel,
+        avg_target_level: avgTargetLevel,
+      });
+    }
+
+    return results;
+  }
+
+  @Get('programs/:official_code')
+  async getProgramByOfficialCode(
+    @Param('official_code') officialCode: string,
+  ) {
+    const root = await this.programService.programRepository.findOne({
+      where: {
+        official_code: officialCode,
+        parent_id: IsNull(),
+      },
+    });
+
+    if (!root) {
+      throw new NotFoundException(
+        `Program with official code "${officialCode}" not found`,
+      );
+    }
+
+    const latestVersion = await this.programService.programRepository.findOne({
+      where: {
+        parent_id: root.id,
+        status: true,
+      },
+      relations: [
+        'risks',
+        'risks.category',
+        'risks.category.category_group',
+        'risks.mitigations',
+        'risks.mitigations.status',
+        'risks.risk_owner',
+        'risks.risk_owner.user',
+        'phase',
+        'roles',
+        'roles.user',
+      ],
+      order: { id: 'DESC', risks: { top: 'ASC', id: 'DESC' } },
+    });
+
+    if (!latestVersion) {
+      throw new NotFoundException(
+        `No submitted version found for program "${officialCode}"`,
+      );
+    }
+
+    return latestVersion;
+  }
+}

--- a/back-end/src/explore/explore.module.ts
+++ b/back-end/src/explore/explore.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ExploreController } from './explore.controller';
+
+@Module({
+  controllers: [ExploreController],
+})
+export class ExploreModule {}

--- a/back-end/src/program/program.controller.ts
+++ b/back-end/src/program/program.controller.ts
@@ -1081,6 +1081,7 @@ export class ProgramController {
           'created_by',
           'roles',
           'roles.user',
+          'phase',
         ],
         // order: { id: 'DESC', risks: { id: 'DESC', top: 'ASC' } },
         order: { risks: { top: 'ASC' } },

--- a/front-end/src/app/Admin/admin-module/exports/exports.component.ts
+++ b/front-end/src/app/Admin/admin-module/exports/exports.component.ts
@@ -208,7 +208,8 @@ export class ExportsComponent {
     cols = buildCols(activePhaseYear);
 
     const narrative = program?.narrative || '';
-    const programLink = `${window.location.origin}/home/${program?.id}/${program?.official_code || ''}`;
+    const versionId = program?.last_version_id || '';
+    const programLink = `${window.location.origin}/explore/${program?.official_code || ''}${versionId ? '/' + versionId : ''}`;
 
     // Row 1: Logo + "Top 5 submitted risks for {Year}" (left)  |  "Click here for more details" (right)
     const titleY = 7;

--- a/front-end/src/app/app-routing.module.ts
+++ b/front-end/src/app/app-routing.module.ts
@@ -249,6 +249,7 @@ const routes: Routes = [
 
   { path: 'explore', component: ExploreListComponent },
   { path: 'explore/:official_code', component: ExploreViewComponent },
+  { path: 'explore/:official_code/:version_id', component: ExploreViewComponent },
   { path: '404', component: PagenotfoundcomponentComponent },
   { path: '**', redirectTo: '/404' },
 ];

--- a/front-end/src/app/app-routing.module.ts
+++ b/front-end/src/app/app-routing.module.ts
@@ -45,6 +45,8 @@ import { SyncClarisaComponent } from './Admin/admin-module/sync-clarisa/sync-cla
 import { OrganizationComponent } from './Admin/admin-module/organization/organization.component';
 import { ProjectsComponent } from './Admin/admin-module/projects/projects.component';
 import { ExportsComponent } from './Admin/admin-module/exports/exports.component';
+import { ExploreListComponent } from './explore/explore-list/explore-list.component';
+import { ExploreViewComponent } from './explore/explore-view/explore-view.component';
 
 const routes: Routes = [
   // { path: 'admin', redirectTo: '/admin/user-management', pathMatch: 'full' },
@@ -245,6 +247,8 @@ const routes: Routes = [
     ],
   },
 
+  { path: 'explore', component: ExploreListComponent },
+  { path: 'explore/:official_code', component: ExploreViewComponent },
   { path: '404', component: PagenotfoundcomponentComponent },
   { path: '**', redirectTo: '/404' },
 ];

--- a/front-end/src/app/app.module.ts
+++ b/front-end/src/app/app.module.ts
@@ -99,6 +99,9 @@ import { AssignOrganizationsComponent } from './home/risk-management/risk-manage
 import { ProjectsComponent } from './Admin/admin-module/projects/projects.component';
 import { ProjectDialogComponentTsComponent } from './Admin/admin-module/projects/project-dialog.component.ts/project-dialog.component.ts.component';
 import { ExportsComponent } from './Admin/admin-module/exports/exports.component';
+import { ExploreListComponent } from './explore/explore-list/explore-list.component';
+import { ExploreViewComponent } from './explore/explore-view/explore-view.component';
+import { ApiExploreService } from './shared-services/explore-services/api-explore.service';
 
 const avatarSourcesOrder = [AvatarSource.INITIALS];
 @NgModule({
@@ -172,6 +175,8 @@ const avatarSourcesOrder = [AvatarSource.INITIALS];
     ProjectsComponent,
     ProjectDialogComponentTsComponent,
     ExportsComponent,
+    ExploreListComponent,
+    ExploreViewComponent,
   ],
   imports: [
     BrowserModule,
@@ -206,6 +211,7 @@ const avatarSourcesOrder = [AvatarSource.INITIALS];
     ApiPublishedService,
     ApiTeamMembersService,
     HeaderService,
+    ApiExploreService,
     AppSocket,
     {
       provide: HTTP_INTERCEPTORS,

--- a/front-end/src/app/explore/explore-list/explore-list.component.html
+++ b/front-end/src/app/explore/explore-list/explore-list.component.html
@@ -1,0 +1,153 @@
+<div class="explore-list-page">
+  <!-- Page Header -->
+  <div class="explore-list-page__header">
+    <div class="explore-list-page__header-content">
+      <h1 class="explore-list-page__title">Explore Programs</h1>
+      <p class="explore-list-page__subtitle">
+        Browse publicly available risk reports from CGIAR projects and programs.
+      </p>
+    </div>
+  </div>
+
+  <!-- Search + Table Section -->
+  <div class="explore-list-page__body">
+    <!-- Search Bar -->
+    <div class="explore-search">
+      <mat-form-field appearance="outline" class="explore-search__field">
+        <mat-label>Search by name or code</mat-label>
+        <input
+          matInput
+          [formControl]="searchControl"
+          placeholder="e.g. INIT-01 or Accelerated Breeding"
+          aria-label="Search programs"
+        />
+        <mat-icon matPrefix class="explore-search__icon">search</mat-icon>
+        <mat-spinner
+          *ngIf="isLoading"
+          matSuffix
+          diameter="20"
+          class="explore-search__spinner"
+        ></mat-spinner>
+      </mat-form-field>
+    </div>
+
+    <!-- Error State -->
+    <div class="explore-error" *ngIf="hasError && !isLoading">
+      <mat-icon class="explore-error__icon">error_outline</mat-icon>
+      <p class="explore-error__text">
+        Unable to load programs. Please try again later.
+      </p>
+    </div>
+
+    <!-- Table -->
+    <div class="explore-table-wrapper mat-elevation-z2" *ngIf="!hasError">
+      <table
+        mat-table
+        [dataSource]="dataSource"
+        class="explore-table"
+        aria-label="Programs table"
+      >
+        <!-- Code Column -->
+        <ng-container matColumnDef="official_code">
+          <th mat-header-cell *matHeaderCellDef>Code</th>
+          <td mat-cell *matCellDef="let program">
+            <span class="explore-table__code">{{ program.official_code }}</span>
+          </td>
+        </ng-container>
+
+        <!-- Name Column -->
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef>Program Name</th>
+          <td mat-cell *matCellDef="let program">
+            <span class="explore-table__name">{{ program.name }}</span>
+          </td>
+        </ng-container>
+
+        <!-- Total Actions Column -->
+        <ng-container matColumnDef="total_actions">
+          <th mat-header-cell *matHeaderCellDef class="center">Actions</th>
+          <td mat-cell *matCellDef="let program" class="center">
+            <span class="explore-table__count">{{ program.total_actions ?? '—' }}</span>
+          </td>
+        </ng-container>
+
+        <!-- Avg Current Level Column -->
+        <ng-container matColumnDef="avg_current">
+          <th mat-header-cell *matHeaderCellDef class="center">Current Score</th>
+          <td mat-cell *matCellDef="let program" class="center">
+            <span
+              class="explore-table__level-badge"
+              [ngClass]="getRiskLevelClass(program.avg_current_level)"
+            >
+              {{ program.avg_current_level }}
+            </span>
+          </td>
+        </ng-container>
+
+        <!-- Avg Target Level Column -->
+        <ng-container matColumnDef="avg_target">
+          <th mat-header-cell *matHeaderCellDef class="center">Target Score</th>
+          <td mat-cell *matCellDef="let program" class="center">
+            <span
+              class="explore-table__level-badge"
+              [ngClass]="getRiskLevelClass(program.avg_target_level)"
+            >
+              {{ program.avg_target_level }}
+            </span>
+          </td>
+        </ng-container>
+
+        <!-- Risks Count Column -->
+        <ng-container matColumnDef="risks_count">
+          <th mat-header-cell *matHeaderCellDef class="center">Risks</th>
+          <td mat-cell *matCellDef="let program" class="center">
+            <span class="explore-table__count">
+              {{ program.risk_count ?? '—' }}
+            </span>
+          </td>
+        </ng-container>
+
+        <!-- Actions Column -->
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef class="center">View</th>
+          <td mat-cell *matCellDef="let program" class="center">
+            <button
+              mat-stroked-button
+              class="explore-table__view-btn"
+              [routerLink]="['/explore', program.official_code]"
+              [attr.aria-label]="'View ' + program.name"
+            >
+              <mat-icon>open_in_new</mat-icon>
+              View
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let program; columns: displayedColumns"
+          class="explore-table__row"
+          [routerLink]="['/explore', program.official_code]"
+          role="link"
+          tabindex="0"
+          (keyup.enter)="viewProgram(program.official_code)"
+        ></tr>
+
+        <!-- Empty State Row -->
+        <tr class="mat-row explore-table__no-data" *matNoDataRow>
+          <td [attr.colspan]="displayedColumns.length" class="explore-table__no-data-cell">
+            <mat-icon>search_off</mat-icon>
+            <span>No programs found matching your search.</span>
+          </td>
+        </tr>
+      </table>
+    </div>
+
+    <!-- Results count -->
+    <p class="explore-list-page__count" *ngIf="!hasError && !isLoading">
+      <span class="explore-list-page__count-num">{{ dataSource.data.length }}</span>
+      program{{ dataSource.data.length !== 1 ? 's' : '' }} found
+    </p>
+  </div>
+</div>

--- a/front-end/src/app/explore/explore-list/explore-list.component.scss
+++ b/front-end/src/app/explore/explore-list/explore-list.component.scss
@@ -1,0 +1,296 @@
+// =====================================================
+// Explore List Page
+// =====================================================
+
+.explore-list-page {
+  min-height: calc(100vh - 120px);
+  background-color: #f5f6fa;
+  font-family: 'Poppins', sans-serif;
+  margin-top: -4px;
+
+  // ---- Page Header ----
+  &__header {
+    background: linear-gradient(135deg, #0f212f 0%, #1a3a52 100%);
+    padding: 4rem 6rem 3.5rem;
+    color: #ffffff;
+  }
+
+  &__header-content {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  &__title {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 3.2rem;
+    font-weight: 700;
+    margin: 0 0 0.8rem;
+    color: #ffffff;
+    letter-spacing: 0.02em;
+  }
+
+  &__subtitle {
+    font-size: 1.5rem;
+    color: rgba(255, 255, 255, 0.75);
+    margin: 0;
+    max-width: 600px;
+    line-height: 1.6;
+  }
+
+  // ---- Body ----
+  &__body {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 2rem 5rem;
+  }
+
+  // ---- Count ----
+  &__count {
+    margin-top: 1.2rem;
+    font-size: 1.3rem;
+    color: #666;
+    text-align: right;
+  }
+
+  &__count-num {
+    font-weight: 600;
+    color: #436280;
+  }
+}
+
+// =====================================================
+// Search
+// =====================================================
+
+.explore-search {
+  margin-bottom: 2.4rem;
+
+  &__field {
+    width: 100%;
+    max-width: 520px;
+
+    ::ng-deep .mat-mdc-form-field-subscript-wrapper {
+      display: none;
+    }
+  }
+
+  &__icon {
+    color: #436280;
+    font-size: 2rem;
+  }
+
+  &__spinner {
+    margin-right: 0.8rem;
+  }
+}
+
+// =====================================================
+// Table
+// =====================================================
+
+.explore-table-wrapper {
+  background: #ffffff;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.explore-table {
+  width: 100%;
+
+  // Header row
+  ::ng-deep .mat-mdc-header-row {
+    background-color: #436280;
+  }
+
+  ::ng-deep .mat-mdc-header-cell {
+    color: #ffffff;
+    font-family: 'Poppins', sans-serif;
+    font-size: 1.3rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    padding: 1.4rem 1.6rem;
+    border-bottom: none;
+  }
+
+  ::ng-deep .mat-mdc-cell {
+    font-family: 'Poppins', sans-serif;
+    font-size: 1.35rem;
+    color: #2d3748;
+    padding: 1.2rem 1.6rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+    vertical-align: middle;
+  }
+
+  &__row {
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+
+    &:hover {
+      background-color: #f0f5f9;
+    }
+
+    &:focus {
+      outline: 2px solid #436280;
+      outline-offset: -2px;
+    }
+  }
+
+  &__code {
+    font-family: 'Josefin Sans', sans-serif;
+    font-weight: 600;
+    font-size: 1.3rem;
+    color: #436280;
+    white-space: nowrap;
+  }
+
+  &__name {
+    font-size: 1.35rem;
+    font-weight: 500;
+    color: #1a2e40;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    max-width: 380px;
+  }
+
+  &__orgs {
+    font-size: 1.25rem;
+    color: #436280;
+  }
+
+  &__orgs-more {
+    font-size: 1.1rem;
+    color: #888;
+    margin-left: 2px;
+  }
+
+  &__level-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 48px;
+    height: 32px;
+    padding: 4px 12px;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 700;
+    color: #ffffff;
+    letter-spacing: 0.02em;
+
+    &.level--green { background-color: #4caf50; }
+    &.level--yellow { background-color: #ff9800; }
+    &.level--orange { background-color: #ff5722; }
+    &.level--red { background-color: #f44336; }
+  }
+
+  &__count {
+    font-weight: 600;
+    font-size: 1.4rem;
+    color: #436280;
+  }
+
+  &__view-btn {
+    font-size: 1.2rem;
+    color: #436280;
+    border-color: #436280;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    white-space: nowrap;
+
+    mat-icon {
+      font-size: 1.6rem;
+      width: 1.6rem;
+      height: 1.6rem;
+    }
+
+    &:hover {
+      background-color: #436280;
+      color: #ffffff;
+    }
+  }
+
+  &__empty {
+    color: #999;
+  }
+
+  // No data row
+  &__no-data-cell {
+    padding: 4rem 2rem;
+    text-align: center;
+    color: #888;
+    font-size: 1.4rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.8rem;
+    width: 100%;
+
+    mat-icon {
+      font-size: 2.4rem;
+      width: 2.4rem;
+      height: 2.4rem;
+      color: #bbb;
+    }
+  }
+}
+
+.center {
+  text-align: center;
+}
+
+// =====================================================
+// Error State
+// =====================================================
+
+.explore-error {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+  background-color: #fff3f3;
+  border: 1px solid #f5c6c6;
+  border-radius: 8px;
+  margin-bottom: 2rem;
+
+  &__icon {
+    color: #d32f2f;
+    font-size: 2.4rem;
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+
+  &__text {
+    font-size: 1.4rem;
+    color: #c62828;
+    margin: 0;
+  }
+}
+
+// =====================================================
+// Responsive
+// =====================================================
+
+@media (max-width: 768px) {
+  .explore-list-page {
+    &__header {
+      padding: 3rem 2rem 2.5rem;
+    }
+
+    &__title {
+      font-size: 2.4rem;
+    }
+
+    &__body {
+      padding: 2rem 1rem 4rem;
+    }
+  }
+
+  .explore-table {
+    &__name {
+      max-width: 200px;
+    }
+  }
+}

--- a/front-end/src/app/explore/explore-list/explore-list.component.ts
+++ b/front-end/src/app/explore/explore-list/explore-list.component.ts
@@ -1,0 +1,110 @@
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+} from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatTableDataSource } from '@angular/material/table';
+import { Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  switchMap,
+  takeUntil,
+  catchError,
+  startWith,
+} from 'rxjs/operators';
+import { of } from 'rxjs';
+import {
+  ApiExploreService,
+  ExploreProgram,
+} from 'src/app/shared-services/explore-services/api-explore.service';
+import { HeaderService } from 'src/app/header.service';
+
+@Component({
+  selector: 'app-explore-list',
+  templateUrl: './explore-list.component.html',
+  styleUrls: ['./explore-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ExploreListComponent implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
+
+  searchControl = new FormControl('');
+  dataSource = new MatTableDataSource<ExploreProgram>([]);
+  displayedColumns: string[] = [
+    'official_code',
+    'name',
+    'total_actions',
+    'avg_current',
+    'avg_target',
+    'risks_count',
+    'actions',
+  ];
+
+  isLoading = false;
+  hasError = false;
+
+  constructor(
+    private exploreService: ApiExploreService,
+    private headerService: HeaderService,
+    private router: Router,
+    private cdr: ChangeDetectorRef
+  ) {
+    this.headerService.background =
+      'linear-gradient(to right, #0F212F, #0E1E2B)';
+    this.headerService.backgroundNavMain =
+      'linear-gradient(to right, #436280, #30455B)';
+    this.headerService.backgroundUserNavButton =
+      'linear-gradient(to right, #436280, #30455B)';
+  }
+
+  ngOnInit(): void {
+    this.searchControl.valueChanges
+      .pipe(
+        startWith(''),
+        debounceTime(400),
+        distinctUntilChanged(),
+        switchMap((term) => {
+          this.isLoading = true;
+          this.hasError = false;
+          this.cdr.markForCheck();
+          return this.exploreService.getPrograms(term || '').pipe(
+            catchError(() => {
+              this.hasError = true;
+              return of([]);
+            })
+          );
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((programs) => {
+        this.dataSource.data = programs;
+        this.isLoading = false;
+        this.cdr.markForCheck();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  viewProgram(official_code: string): void {
+    this.router.navigate(['/explore', official_code]);
+  }
+
+  getRiskLevelClass(level: number): string {
+    if (level <= 4) return 'level--green';
+    if (level <= 9) return 'level--yellow';
+    if (level <= 15) return 'level--orange';
+    return 'level--red';
+  }
+
+  trackByCode(_index: number, program: ExploreProgram): string {
+    return program.official_code;
+  }
+}

--- a/front-end/src/app/explore/explore-view/explore-view.component.html
+++ b/front-end/src/app/explore/explore-view/explore-view.component.html
@@ -1,0 +1,357 @@
+<!-- Loading State -->
+<div class="explore-view-loading" *ngIf="isLoading">
+  <mat-spinner diameter="48"></mat-spinner>
+  <p>Loading program data...</p>
+</div>
+
+<!-- Error State -->
+<div class="explore-view-error" *ngIf="hasError && !isLoading">
+  <div class="explore-view-error__box">
+    <mat-icon class="explore-view-error__icon">error_outline</mat-icon>
+    <h2 class="explore-view-error__title">Program Not Available</h2>
+    <p class="explore-view-error__text">{{ errorMessage }}</p>
+    <button mat-raised-button color="primary" (click)="goBack()">
+      <mat-icon>arrow_back</mat-icon>
+      Back to Explore
+    </button>
+  </div>
+</div>
+
+<!-- Program Detail -->
+<div class="explore-view" *ngIf="program && !isLoading && !hasError">
+
+  <!-- ===== Program Header ===== -->
+  <div class="explore-view__header">
+    <div class="explore-view__header-content">
+      <button
+        mat-icon-button
+        class="explore-view__back-btn"
+        (click)="goBack()"
+        matTooltip="Back to Explore"
+        aria-label="Back to Explore"
+      >
+        <mat-icon>arrow_back</mat-icon>
+      </button>
+
+      <div class="explore-view__program-meta">
+        <span class="explore-view__code">{{ program.official_code }}</span>
+        <span class="explore-view__phase" *ngIf="program.phase?.name">
+          {{ program.phase?.name }}
+        </span>
+        <span class="explore-view__status-badge">
+          Published
+        </span>
+      </div>
+
+      <h1 class="explore-view__program-name">{{ program.name }}</h1>
+
+      <!-- Narrative -->
+      <div class="explore-view__narrative" *ngIf="program.narrative">
+        <mat-icon class="explore-view__narrative-icon">format_quote</mat-icon>
+        <p class="explore-view__narrative-text">{{ program.narrative }}</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===== Page Body ===== -->
+  <div class="explore-view__body">
+
+    <!-- ===== Summary Charts ===== -->
+    <div class="explore-charts" *ngIf="program.risks?.length">
+
+      <!-- Summary Cards Row -->
+      <div class="explore-charts__summary-row">
+        <div class="explore-summary-card">
+          <span class="explore-summary-card__value">{{ program.risks?.length }}</span>
+          <span class="explore-summary-card__label">Total Risks</span>
+        </div>
+        <div class="explore-summary-card">
+          <span class="explore-summary-card__value explore-summary-card__value--current" [ngClass]="getRiskLevelClass(avgCurrentLevel)">
+            {{ avgCurrentLevel }}
+          </span>
+          <span class="explore-summary-card__label">Avg Current Level</span>
+        </div>
+        <div class="explore-summary-card">
+          <span class="explore-summary-card__value explore-summary-card__value--target" [ngClass]="getRiskLevelClass(avgTargetLevel)">
+            {{ avgTargetLevel }}
+          </span>
+          <span class="explore-summary-card__label">Avg Target Level</span>
+        </div>
+        <div class="explore-summary-card">
+          <span class="explore-summary-card__value">{{ totalActions }}</span>
+          <span class="explore-summary-card__label">Total Actions</span>
+        </div>
+      </div>
+
+      <!-- Two-column chart row -->
+      <div class="explore-charts__row">
+        <!-- Status of Actions -->
+        <mat-card class="explore-chart-card">
+          <mat-card-header>
+            <mat-card-title>Status of Actions & Controls</mat-card-title>
+          </mat-card-header>
+          <mat-card-content>
+            <highcharts-chart
+              [Highcharts]="Highcharts"
+              [options]="actionsChartOptions"
+              style="width: 100%; display: block;"
+            ></highcharts-chart>
+          </mat-card-content>
+        </mat-card>
+
+        <!-- Category Distribution (Pie Chart) -->
+        <mat-card class="explore-chart-card">
+          <mat-card-header>
+            <mat-card-title>Risks by Category</mat-card-title>
+          </mat-card-header>
+          <mat-card-content>
+            <highcharts-chart
+              [Highcharts]="Highcharts"
+              [options]="categoryChartOptions"
+              style="width: 100%; display: block;"
+            ></highcharts-chart>
+          </mat-card-content>
+        </mat-card>
+      </div>
+    </div>
+
+    <!-- ===== Meta: Organizations + Team Members ===== -->
+    <div class="explore-view__meta-row">
+
+      <!-- Organizations -->
+      <mat-card class="explore-meta-card" *ngIf="program.organizations?.length">
+        <mat-card-header>
+          <mat-icon mat-card-avatar class="explore-meta-card__icon">business</mat-icon>
+          <mat-card-title>Organizations</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="explore-meta-card__chips">
+            <mat-chip-listbox aria-label="Organizations">
+              <mat-chip
+                *ngFor="let org of program.organizations"
+                class="explore-meta-card__chip"
+                [matTooltip]="org.name"
+                disableRipple
+              >
+                {{ org.acronym || org.name }}
+              </mat-chip>
+            </mat-chip-listbox>
+          </div>
+        </mat-card-content>
+      </mat-card>
+
+      <!-- Team Members -->
+      <mat-card class="explore-meta-card" *ngIf="program.roles?.length">
+        <mat-card-header>
+          <mat-icon mat-card-avatar class="explore-meta-card__icon">group</mat-icon>
+          <mat-card-title>Team Members</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="explore-team">
+            <ng-container *ngIf="teamLeads.length">
+              <p class="explore-team__role-label">Leadership</p>
+              <div
+                class="explore-team__member"
+                *ngFor="let member of teamLeads; trackBy: trackByRoleId"
+              >
+                <mat-icon class="explore-team__icon">person</mat-icon>
+                <span class="explore-team__name">
+                  {{ member.user?.full_name || member.email }}
+                </span>
+                <span class="explore-team__role-badge explore-team__role-badge--lead">
+                  {{ member.role }}
+                </span>
+              </div>
+            </ng-container>
+
+            <ng-container *ngIf="teamMembers.length">
+              <p class="explore-team__role-label">Members</p>
+              <div
+                class="explore-team__member"
+                *ngFor="let member of teamMembers; trackBy: trackByRoleId"
+              >
+                <mat-icon class="explore-team__icon">person_outline</mat-icon>
+                <span class="explore-team__name">
+                  {{ member.user?.full_name || member.email }}
+                </span>
+                <span class="explore-team__role-badge">{{ member.role }}</span>
+              </div>
+            </ng-container>
+          </div>
+        </mat-card-content>
+      </mat-card>
+    </div>
+
+    <!-- ===== Risks Section ===== -->
+    <div class="explore-risks">
+      <div class="explore-risks__header">
+        <h2 class="explore-risks__title">
+          <mat-icon class="explore-risks__title-icon">assessment</mat-icon>
+          Identified Risks
+        </h2>
+        <span class="explore-risks__count">
+          {{ program.risks?.length || 0 }} risk{{ (program.risks?.length || 0) !== 1 ? 's' : '' }}
+        </span>
+      </div>
+
+      <!-- No risks state -->
+      <div class="explore-risks__empty" *ngIf="!program.risks?.length">
+        <mat-icon>search_off</mat-icon>
+        <p>No risks have been submitted for this program yet.</p>
+      </div>
+
+      <!-- Risk expansion panels — always expanded -->
+      <mat-accordion
+        class="explore-risks__accordion"
+        *ngIf="program.risks?.length"
+        multi
+      >
+        <mat-expansion-panel
+          class="explore-risk-panel"
+          *ngFor="let risk of program.risks; let i = index; trackBy: trackByRiskId"
+          [expanded]="true"
+          [attr.aria-label]="'Risk ' + (i + 1) + ': ' + risk.title"
+        >
+          <!-- Panel Header -->
+          <mat-expansion-panel-header class="explore-risk-panel__header">
+            <mat-panel-title class="explore-risk-panel__title-row">
+              <span class="explore-risk-panel__index">#{{ i + 1 }}</span>
+              <span class="explore-risk-panel__title">{{ risk.title }}</span>
+            </mat-panel-title>
+            <mat-panel-description class="explore-risk-panel__description-row">
+              <!-- Category -->
+              <span
+                class="explore-risk-panel__category"
+                *ngIf="risk.category"
+                [matTooltip]="risk.category?.category_group?.name || ''"
+              >
+                {{ risk.category.title }}
+              </span>
+
+              <!-- Level badges in header -->
+              <span class="explore-risk-panel__levels">
+                <span
+                  class="explore-level-badge"
+                  [ngClass]="getRiskLevelClass(getRiskLevel(risk.current_likelihood, risk.current_impact))"
+                  matTooltip="Current risk level"
+                >
+                  C: {{ getRiskLevel(risk.current_likelihood, risk.current_impact) }}
+                </span>
+                <span
+                  class="explore-level-badge"
+                  [ngClass]="getRiskLevelClass(getRiskLevel(risk.target_likelihood, risk.target_impact))"
+                  matTooltip="Target risk level"
+                >
+                  T: {{ getRiskLevel(risk.target_likelihood, risk.target_impact) }}
+                </span>
+              </span>
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+
+          <!-- Panel Content -->
+          <div class="explore-risk-detail">
+
+            <!-- Description -->
+            <div class="explore-risk-detail__section" *ngIf="risk.description">
+              <h4 class="explore-risk-detail__section-title">Description</h4>
+              <p class="explore-risk-detail__text">{{ risk.description }}</p>
+            </div>
+
+            <!-- Risk Metrics Grid -->
+            <div class="explore-risk-detail__metrics">
+              <!-- Current Level Card -->
+              <div class="explore-metric-card">
+                <p class="explore-metric-card__label">Current Risk Level</p>
+                <div class="explore-metric-card__values">
+                  <span class="explore-metric-card__sub">
+                    L: {{ risk.current_likelihood }} &times; I: {{ risk.current_impact }}
+                  </span>
+                  <span
+                    class="explore-metric-card__level"
+                    [ngClass]="getRiskLevelClass(getRiskLevel(risk.current_likelihood, risk.current_impact))"
+                  >
+                    {{ getRiskLevel(risk.current_likelihood, risk.current_impact) }}
+                  </span>
+                </div>
+              </div>
+
+              <!-- Target Level Card -->
+              <div class="explore-metric-card">
+                <p class="explore-metric-card__label">Target Risk Level</p>
+                <div class="explore-metric-card__values">
+                  <span class="explore-metric-card__sub">
+                    L: {{ risk.target_likelihood }} &times; I: {{ risk.target_impact }}
+                  </span>
+                  <span
+                    class="explore-metric-card__level"
+                    [ngClass]="getRiskLevelClass(getRiskLevel(risk.target_likelihood, risk.target_impact))"
+                  >
+                    {{ getRiskLevel(risk.target_likelihood, risk.target_impact) }}
+                  </span>
+                </div>
+              </div>
+
+              <!-- Risk Owner -->
+              <div class="explore-metric-card" *ngIf="risk.risk_owner">
+                <p class="explore-metric-card__label">Risk Owner</p>
+                <div class="explore-metric-card__values">
+                  <mat-icon class="explore-metric-card__person-icon">person</mat-icon>
+                  <span class="explore-metric-card__owner">
+                    {{ risk.risk_owner?.user?.full_name || risk.risk_owner?.email || '—' }}
+                  </span>
+                </div>
+              </div>
+
+              <!-- Due Date -->
+              <div class="explore-metric-card" *ngIf="risk.due_date">
+                <p class="explore-metric-card__label">Due Date</p>
+                <div class="explore-metric-card__values">
+                  <mat-icon class="explore-metric-card__calendar-icon">event</mat-icon>
+                  <span class="explore-metric-card__date">
+                    {{ risk.due_date | date: 'dd/MM/yyyy' }}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Mitigations -->
+            <div class="explore-risk-detail__section" *ngIf="risk.mitigations?.length">
+              <h4 class="explore-risk-detail__section-title">
+                Actions &amp; Controls to Manage Risk
+                <span class="explore-risk-detail__mitigation-count">
+                  ({{ risk.mitigations?.length }})
+                </span>
+              </h4>
+              <div class="explore-mitigations">
+                <div
+                  class="explore-mitigation"
+                  *ngFor="let m of risk.mitigations; let mi = index; trackBy: trackByMitigationId"
+                >
+                  <span class="explore-mitigation__num">{{ mi + 1 }}</span>
+                  <p class="explore-mitigation__description">{{ m.description }}</p>
+                  <span
+                    class="explore-mitigation__status"
+                    *ngIf="m.status"
+                  >
+                    {{ m.status.title }}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <!-- No mitigations -->
+            <div
+              class="explore-risk-detail__section explore-risk-detail__no-mitigations"
+              *ngIf="!risk.mitigations?.length"
+            >
+              <mat-icon>info_outline</mat-icon>
+              <span>No mitigation actions recorded for this risk.</span>
+            </div>
+
+          </div>
+        </mat-expansion-panel>
+      </mat-accordion>
+    </div>
+
+  </div>
+</div>

--- a/front-end/src/app/explore/explore-view/explore-view.component.scss
+++ b/front-end/src/app/explore/explore-view/explore-view.component.scss
@@ -1,0 +1,795 @@
+// =====================================================
+// Explore View Page
+// =====================================================
+
+$color-green: #4caf50;
+$color-yellow: #ff9800;
+$color-orange: #ff5722;
+$color-red: #f44336;
+$color-brand: #436280;
+$color-brand-dark: #0f212f;
+
+// =====================================================
+// Loading & Error States
+// =====================================================
+
+.explore-view-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 50vh;
+  gap: 2rem;
+  font-family: 'Poppins', sans-serif;
+  font-size: 1.4rem;
+  color: #666;
+}
+
+.explore-view-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 2rem;
+
+  &__box {
+    text-align: center;
+    max-width: 480px;
+    padding: 4rem 3rem;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  }
+
+  &__icon {
+    font-size: 5rem;
+    width: 5rem;
+    height: 5rem;
+    color: #e53935;
+    margin-bottom: 1.6rem;
+  }
+
+  &__title {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 2.4rem;
+    color: $color-brand-dark;
+    margin: 0 0 1rem;
+  }
+
+  &__text {
+    font-size: 1.4rem;
+    color: #666;
+    margin: 0 0 2.4rem;
+    line-height: 1.6;
+  }
+}
+
+// =====================================================
+// Program Header
+// =====================================================
+
+.explore-view {
+  min-height: calc(100vh - 120px);
+  background-color: #f5f6fa;
+  font-family: 'Poppins', sans-serif;
+  margin-top: -4px;
+
+  &__header {
+    background: linear-gradient(135deg, $color-brand-dark 0%, #1a3a52 100%);
+    padding: 3.5rem 6rem 4rem;
+    color: #ffffff;
+    position: relative;
+  }
+
+  &__header-content {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  &__back-btn {
+    color: rgba(255, 255, 255, 0.7);
+    margin-bottom: 1.5rem;
+    display: block;
+
+    &:hover {
+      color: #ffffff;
+      background-color: rgba(255, 255, 255, 0.1);
+    }
+
+    mat-icon {
+      font-size: 2.2rem;
+    }
+  }
+
+  &__program-meta {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.2rem;
+  }
+
+  &__code {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+    background: rgba(255, 255, 255, 0.15);
+    padding: 0.3rem 1rem;
+    border-radius: 4px;
+    color: #ffffff;
+    letter-spacing: 0.04em;
+  }
+
+  &__phase {
+    font-size: 1.3rem;
+    color: rgba(255, 255, 255, 0.7);
+    background: rgba(255, 255, 255, 0.1);
+    padding: 0.3rem 1rem;
+    border-radius: 4px;
+  }
+
+  &__status-badge {
+    font-size: 1.2rem;
+    padding: 0.3rem 1rem;
+    border-radius: 12px;
+    background-color: rgba(255, 255, 255, 0.2);
+    color: #ffffff;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+  }
+
+  &__program-name {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 2.8rem;
+    font-weight: 700;
+    color: #ffffff;
+    margin: 0 0 1.6rem;
+    line-height: 1.3;
+    max-width: 900px;
+  }
+
+  &__narrative {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    background: rgba(255, 255, 255, 0.08);
+    border-left: 3px solid rgba(255, 255, 255, 0.4);
+    padding: 1.4rem 1.6rem;
+    border-radius: 0 6px 6px 0;
+    max-width: 860px;
+  }
+
+  &__narrative-icon {
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 2.4rem;
+    width: 2.4rem;
+    height: 2.4rem;
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+  }
+
+  &__narrative-text {
+    font-size: 1.4rem;
+    color: rgba(255, 255, 255, 0.85);
+    margin: 0;
+    line-height: 1.7;
+    font-style: italic;
+  }
+
+  // Body
+  &__body {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 2rem 6rem;
+  }
+
+  &__meta-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    margin-bottom: 3rem;
+  }
+}
+
+// =====================================================
+// Summary Charts Section
+// =====================================================
+
+.explore-charts {
+  margin-bottom: 3rem;
+
+  &__summary-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1.6rem;
+    margin-bottom: 2rem;
+  }
+
+  &__row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+    gap: 2rem;
+  }
+}
+
+.explore-summary-card {
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
+  padding: 2rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+
+  &__value {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 3rem;
+    font-weight: 700;
+    color: $color-brand-dark;
+
+    &--current,
+    &--target {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 6rem;
+      padding: 0.5rem 1.6rem;
+      border-radius: 8px;
+      color: #ffffff;
+      font-size: 2.6rem;
+
+      &.level--green { background-color: $color-green; }
+      &.level--yellow { background-color: $color-yellow; }
+      &.level--orange { background-color: $color-orange; }
+      &.level--red { background-color: $color-red; }
+    }
+
+    &--flag {
+      color: $color-red;
+    }
+  }
+
+  &__label {
+    font-size: 1.2rem;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+    text-align: center;
+  }
+}
+
+.explore-chart-card {
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
+
+  ::ng-deep .mat-mdc-card-header {
+    padding: 1.6rem 1.6rem 0.8rem;
+  }
+
+  ::ng-deep .mat-mdc-card-title {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: $color-brand-dark;
+  }
+
+  ::ng-deep .mat-mdc-card-content {
+    padding: 0.8rem 1.6rem 1.6rem;
+  }
+}
+
+
+// =====================================================
+// Meta Cards
+// =====================================================
+
+.explore-meta-card {
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
+
+  ::ng-deep .mat-mdc-card-header {
+    padding: 1.6rem 1.6rem 0;
+  }
+
+  ::ng-deep .mat-mdc-card-title {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 1.6rem;
+    font-weight: 600;
+    color: $color-brand-dark;
+  }
+
+  ::ng-deep .mat-mdc-card-content {
+    padding: 1.2rem 1.6rem 1.6rem;
+  }
+
+  &__icon {
+    color: $color-brand;
+    font-size: 2.2rem;
+    width: 2.2rem;
+    height: 2.2rem;
+  }
+
+  &__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    padding: 0;
+  }
+
+  &__chip {
+    font-size: 1.2rem;
+    height: 2.6rem;
+    background-color: #e8f0f7;
+    color: #2d5f7e;
+    border: 1px solid #b8d0e4;
+
+    ::ng-deep .mat-mdc-chip-action-label {
+      font-size: 1.2rem;
+    }
+  }
+}
+
+// =====================================================
+// Team Members
+// =====================================================
+
+.explore-team {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+
+  &__role-label {
+    font-size: 1.1rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #888;
+    margin: 0.8rem 0 0.4rem;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  &__member {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    padding: 0.6rem 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__icon {
+    font-size: 1.8rem;
+    width: 1.8rem;
+    height: 1.8rem;
+    color: $color-brand;
+    flex-shrink: 0;
+  }
+
+  &__name {
+    font-size: 1.35rem;
+    color: #2d3748;
+    flex: 1;
+  }
+
+  &__role-badge {
+    font-size: 1.1rem;
+    padding: 0.2rem 0.8rem;
+    border-radius: 10px;
+    background-color: #e8e8e8;
+    color: #555;
+    white-space: nowrap;
+
+    &--lead {
+      background-color: #e3edfa;
+      color: #2056a8;
+      border: 1px solid #b3cff0;
+    }
+  }
+}
+
+// =====================================================
+// Risks Section
+// =====================================================
+
+.explore-risks {
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.6rem;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  &__title {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 2.2rem;
+    font-weight: 600;
+    color: $color-brand-dark;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+  }
+
+  &__title-icon {
+    color: $color-brand;
+    font-size: 2.4rem;
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+
+  &__count {
+    font-size: 1.3rem;
+    background: #e8f0f7;
+    padding: 0.4rem 1.2rem;
+    border-radius: 12px;
+    color: $color-brand;
+    font-weight: 600;
+  }
+
+  &__empty {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 3rem 2rem;
+    background: #ffffff;
+    border-radius: 8px;
+    color: #888;
+    font-size: 1.4rem;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+
+    mat-icon {
+      font-size: 2.4rem;
+      width: 2.4rem;
+      height: 2.4rem;
+      color: #ccc;
+    }
+  }
+
+  &__accordion {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+}
+
+// =====================================================
+// Risk Expansion Panel
+// =====================================================
+
+.explore-risk-panel {
+  border-radius: 8px !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07) !important;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+
+  &__header {
+    min-height: 5.6rem;
+    background-color: #ffffff;
+
+    ::ng-deep .mat-expansion-panel-header-title,
+    ::ng-deep .mat-expansion-panel-header-description {
+      align-items: center;
+    }
+  }
+
+  &__title-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__index {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: $color-brand;
+    flex-shrink: 0;
+    padding-top: 0.1rem;
+  }
+
+  &__title {
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: #1a2e40;
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  &__description-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-shrink: 0;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    max-width: 300px;
+  }
+
+  &__category {
+    font-size: 1.15rem;
+    color: #666;
+    background-color: #f0f4f8;
+    padding: 0.2rem 0.8rem;
+    border-radius: 4px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 160px;
+  }
+
+  &__levels {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+}
+
+// =====================================================
+// Risk Level Badge — all white text
+// =====================================================
+
+.explore-level-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.6rem;
+  padding: 0.25rem 0.7rem;
+  border-radius: 4px;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #ffffff;
+  cursor: default;
+
+  &.level--green { background-color: $color-green; }
+  &.level--yellow { background-color: $color-yellow; }
+  &.level--orange { background-color: $color-orange; }
+  &.level--red { background-color: $color-red; }
+}
+
+// =====================================================
+// Risk Detail Content
+// =====================================================
+
+.explore-risk-detail {
+  padding: 0 0.8rem 0.8rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.07);
+  background-color: #fafbfc;
+
+  &__section {
+    padding: 1.6rem 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__section-title {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: $color-brand-dark;
+    margin: 0 0 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  &__text {
+    font-size: 1.35rem;
+    color: #444;
+    margin: 0;
+    line-height: 1.7;
+  }
+
+  &__mitigation-count {
+    font-weight: 400;
+    color: #888;
+    font-size: 1.2rem;
+  }
+
+  &__metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.2rem;
+    padding: 1.6rem 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  }
+
+  &__no-mitigations {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    color: #999;
+    font-size: 1.3rem;
+
+    mat-icon {
+      font-size: 1.8rem;
+      width: 1.8rem;
+      height: 1.8rem;
+      color: #ccc;
+    }
+  }
+}
+
+// =====================================================
+// Metric Cards — white text on level badges
+// =====================================================
+
+.explore-metric-card {
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 6px;
+  padding: 1.2rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+
+  &__label {
+    font-size: 1.1rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #888;
+    margin: 0;
+  }
+
+  &__values {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.8rem;
+  }
+
+  &__sub {
+    font-size: 1.2rem;
+    color: #555;
+  }
+
+  &__level {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 3.8rem;
+    padding: 0.3rem 0.8rem;
+    border-radius: 4px;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #ffffff;
+
+    &.level--green { background-color: $color-green; }
+    &.level--yellow { background-color: $color-yellow; }
+    &.level--orange { background-color: $color-orange; }
+    &.level--red { background-color: $color-red; }
+  }
+
+  &__person-icon,
+  &__calendar-icon {
+    font-size: 1.8rem;
+    width: 1.8rem;
+    height: 1.8rem;
+    color: $color-brand;
+  }
+
+  &__owner,
+  &__date {
+    font-size: 1.35rem;
+    color: #333;
+    font-weight: 500;
+  }
+}
+
+// =====================================================
+// Mitigations — visible status badges
+// =====================================================
+
+.explore-mitigations {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.explore-mitigation {
+  display: grid;
+  grid-template-columns: 2.4rem 1fr auto;
+  align-items: flex-start;
+  gap: 1rem;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.07);
+  border-radius: 6px;
+  padding: 1.2rem 1.4rem;
+
+  &__num {
+    font-family: 'Josefin Sans', sans-serif;
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: $color-brand;
+    line-height: 1.6;
+    text-align: center;
+  }
+
+  &__description {
+    font-size: 1.35rem;
+    color: #333;
+    margin: 0;
+    line-height: 1.6;
+  }
+
+  &__status {
+    font-size: 1.15rem;
+    padding: 0.3rem 0.9rem;
+    border-radius: 10px;
+    font-weight: 600;
+    white-space: nowrap;
+    align-self: flex-start;
+    flex-shrink: 0;
+    background-color: #e3edfa;
+    color: #2056a8;
+    border: 1px solid #b3cff0;
+  }
+}
+
+// =====================================================
+// Responsive
+// =====================================================
+
+@media (max-width: 768px) {
+  .explore-view {
+    &__header {
+      padding: 3rem 1.5rem 3rem;
+    }
+
+    &__program-name {
+      font-size: 2rem;
+    }
+
+    &__body {
+      padding: 2rem 1rem 4rem;
+    }
+
+    &__meta-row {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .explore-charts {
+    &__summary-row {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    &__row {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .explore-risk-panel {
+    &__description-row {
+      display: none;
+    }
+  }
+
+  .explore-mitigation {
+    grid-template-columns: 2rem 1fr;
+
+    &__status {
+      grid-column: 2;
+      margin-top: 0.4rem;
+    }
+  }
+
+}

--- a/front-end/src/app/explore/explore-view/explore-view.component.ts
+++ b/front-end/src/app/explore/explore-view/explore-view.component.ts
@@ -1,0 +1,252 @@
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+} from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil, catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+import * as Highcharts from 'highcharts';
+import {
+  ApiExploreService,
+  ExploreProgramDetail,
+  ExploreRisk,
+} from 'src/app/shared-services/explore-services/api-explore.service';
+import { HeaderService } from 'src/app/header.service';
+
+@Component({
+  selector: 'app-explore-view',
+  templateUrl: './explore-view.component.html',
+  styleUrls: ['./explore-view.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ExploreViewComponent implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
+
+  program: ExploreProgramDetail | null = null;
+  isLoading = true;
+  hasError = false;
+  errorMessage = '';
+
+  // Chart data
+  Highcharts = Highcharts;
+  categoryChartOptions: Highcharts.Options = {};
+  actionsChartOptions: Highcharts.Options = {};
+  categoryData: { name: string; count: number }[] = [];
+  avgCurrentLevel = 0;
+  avgTargetLevel = 0;
+  totalActions = 0;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private exploreService: ApiExploreService,
+    private headerService: HeaderService,
+    private cdr: ChangeDetectorRef
+  ) {
+    this.headerService.background =
+      'linear-gradient(to right, #0F212F, #0E1E2B)';
+    this.headerService.backgroundNavMain =
+      'linear-gradient(to right, #436280, #30455B)';
+    this.headerService.backgroundUserNavButton =
+      'linear-gradient(to right, #436280, #30455B)';
+  }
+
+  ngOnInit(): void {
+    const official_code = this.route.snapshot.paramMap.get('official_code');
+    if (!official_code) {
+      this.router.navigate(['/explore']);
+      return;
+    }
+
+    this.exploreService
+      .getProgramByCode(official_code)
+      .pipe(
+        catchError((err) => {
+          this.hasError = true;
+          this.errorMessage =
+            err?.status === 404
+              ? 'Program not found or has no published submissions.'
+              : 'Unable to load program data. Please try again later.';
+          return of(null);
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((data) => {
+        this.program = data;
+        if (data?.risks?.length) {
+          this.computeChartData(data.risks);
+        }
+        this.isLoading = false;
+        this.cdr.markForCheck();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private computeChartData(risks: ExploreRisk[]): void {
+    // Category distribution
+    const catMap = new Map<string, number>();
+    risks.forEach((r) => {
+      const cat = r.category?.title || 'Uncategorized';
+      catMap.set(cat, (catMap.get(cat) || 0) + 1);
+    });
+    this.categoryData = Array.from(catMap.entries())
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count);
+
+    // Pie chart options
+    this.categoryChartOptions = {
+      chart: { type: 'pie', height: 280, backgroundColor: 'transparent' },
+      title: { text: undefined },
+      credits: { enabled: false },
+      tooltip: {
+        style: { fontSize: '14px', fontFamily: 'Poppins, sans-serif' },
+        pointFormat: '<b>{point.y}</b> risk(s) ({point.percentage:.1f}%)',
+      },
+      plotOptions: {
+        pie: {
+          allowPointSelect: true,
+          cursor: 'pointer',
+          dataLabels: {
+            enabled: true,
+            format: '{point.name}: {point.y}',
+            style: { fontSize: '12px', fontFamily: 'Poppins, sans-serif', fontWeight: '500' },
+          },
+        },
+      },
+      series: [
+        {
+          type: 'pie',
+          name: 'Risks',
+          data: this.categoryData.map((c) => ({
+            name: c.name,
+            y: c.count,
+          })),
+        },
+      ],
+    };
+
+    // Mitigation status distribution
+    const statusMap = new Map<string, number>();
+    risks.forEach((r) => {
+      r.mitigations?.forEach((m) => {
+        const status = m.status?.title || 'No Status';
+        statusMap.set(status, (statusMap.get(status) || 0) + 1);
+      });
+    });
+    const actionsData = Array.from(statusMap.entries())
+      .map(([name, count]) => ({ name, y: count }))
+      .sort((a, b) => b.y - a.y);
+
+    this.actionsChartOptions = {
+      chart: { type: 'pie', height: 280, backgroundColor: 'transparent' },
+      title: { text: undefined },
+      credits: { enabled: false },
+      tooltip: {
+        style: { fontSize: '14px', fontFamily: 'Poppins, sans-serif' },
+        pointFormat: '<b>{point.y}</b> action(s) ({point.percentage:.1f}%)',
+      },
+      plotOptions: {
+        pie: {
+          allowPointSelect: true,
+          cursor: 'pointer',
+          dataLabels: {
+            enabled: true,
+            format: '{point.name}: {point.y}',
+            style: { fontSize: '12px', fontFamily: 'Poppins, sans-serif', fontWeight: '500' },
+          },
+        },
+      },
+      series: [
+        {
+          type: 'pie',
+          name: 'Actions',
+          data: actionsData,
+        },
+      ],
+    };
+
+    // Total actions count
+    this.totalActions = risks.reduce(
+      (sum, r) => sum + (r.mitigations?.length || 0),
+      0
+    );
+
+    // Averages
+    this.avgCurrentLevel =
+      Math.round(
+        (risks.reduce(
+          (sum, r) =>
+            sum + this.getRiskLevel(r.current_likelihood, r.current_impact),
+          0
+        ) /
+          risks.length) *
+          100
+      ) / 100;
+    this.avgTargetLevel =
+      Math.round(
+        (risks.reduce(
+          (sum, r) =>
+            sum + this.getRiskLevel(r.target_likelihood, r.target_impact),
+          0
+        ) /
+          risks.length) *
+          100
+      ) / 100;
+
+  }
+
+  goBack(): void {
+    this.router.navigate(['/explore']);
+  }
+
+  getRiskLevel(likelihood: number, impact: number): number {
+    return (likelihood || 0) * (impact || 0);
+  }
+
+  getRiskLevelClass(level: number): string {
+    if (level <= 4) return 'level--green';
+    if (level <= 9) return 'level--yellow';
+    if (level <= 15) return 'level--orange';
+    return 'level--red';
+  }
+
+  get teamLeads(): any[] {
+    return (
+      this.program?.roles?.filter(
+        (r) =>
+          r.role?.toLowerCase() === 'leader' ||
+          r.role?.toLowerCase() === 'lead'
+      ) || []
+    );
+  }
+
+  get teamMembers(): any[] {
+    return (
+      this.program?.roles?.filter(
+        (r) =>
+          r.role?.toLowerCase() !== 'leader' &&
+          r.role?.toLowerCase() !== 'lead'
+      ) || []
+    );
+  }
+
+  trackByRiskId(_index: number, risk: ExploreRisk): number {
+    return risk.id;
+  }
+
+  trackByMitigationId(_index: number, m: any): number {
+    return m.id;
+  }
+
+  trackByRoleId(_index: number, r: any): number {
+    return r.id;
+  }
+}

--- a/front-end/src/app/explore/explore-view/explore-view.component.ts
+++ b/front-end/src/app/explore/explore-view/explore-view.component.ts
@@ -57,13 +57,14 @@ export class ExploreViewComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const official_code = this.route.snapshot.paramMap.get('official_code');
+    const version_id = this.route.snapshot.paramMap.get('version_id');
     if (!official_code) {
       this.router.navigate(['/explore']);
       return;
     }
 
     this.exploreService
-      .getProgramByCode(official_code)
+      .getProgramByCode(official_code, version_id || undefined)
       .pipe(
         catchError((err) => {
           this.hasError = true;

--- a/front-end/src/app/header/header.component.html
+++ b/front-end/src/app/header/header.component.html
@@ -57,6 +57,15 @@
           </li>
           <li>
             <a
+              routerLink="explore"
+              class="main-nav-link cool-link"
+              routerLinkActive="active"
+            >
+              <span>Explore</span>
+            </a>
+          </li>
+          <li>
+            <a
               routerLink="glossary"
               class="main-nav-link cool-link"
               routerLinkActive="active"

--- a/front-end/src/app/home/risk-management/risk-report/published-versions/accelerated-breeding-version/accelerated-breeding-version.component.html
+++ b/front-end/src/app/home/risk-management/risk-report/published-versions/accelerated-breeding-version/accelerated-breeding-version.component.html
@@ -86,7 +86,31 @@
                   /></svg
               ></mat-icon>
 
-              Export data
+              Export Excel
+            </button>
+          </div>
+          <div>
+            <button
+              class="risk-management-export-submitted-btn"
+              mat-raised-button
+              (click)="exportLandscapePdf()"
+            >
+              <mat-icon class="risk-management-export-box-icon">
+                <svg
+                  class="risk-management-export-box-icon"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="22"
+                  height="21"
+                  viewBox="0 0 22 21"
+                  fill="none"
+                >
+                  <path
+                    d="M5.65951 17.6484C5.15534 17.6484 4.72389 17.4772 4.36517 17.1348C4.00584 16.7918 3.82617 16.3797 3.82617 15.8984V13.2734H5.65951V15.8984H16.6595V13.2734H18.4928V15.8984C18.4928 16.3797 18.3135 16.7918 17.9548 17.1348C17.5954 17.4772 17.1637 17.6484 16.6595 17.6484H5.65951ZM11.1595 14.1484L6.57617 9.77344L7.8595 8.50469L10.2428 10.7797V3.64844H12.0762V10.7797L14.4595 8.50469L15.7428 9.77344L11.1595 14.1484Z"
+                    fill="white"
+                  /></svg
+              ></mat-icon>
+
+              Export PDF
             </button>
           </div>
         </div>
@@ -99,6 +123,8 @@
       [dataSource]="dataSource"
       [showReduntent]="showReduntent"
       [titlePage]="titlePage"
+      [savePdf]="savePdf"
+      [programData]="sciencePrograms"
     >
     </app-risk-report-table>
   </div>

--- a/front-end/src/app/home/risk-management/risk-report/published-versions/accelerated-breeding-version/accelerated-breeding-version.component.ts
+++ b/front-end/src/app/home/risk-management/risk-report/published-versions/accelerated-breeding-version/accelerated-breeding-version.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, EventEmitter, ViewChild } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute, Router } from '@angular/router';
 import { InitiativesService } from 'src/app/services/initiatives.service';
@@ -26,6 +26,7 @@ export class AcceleratedBreedingVersionComponent {
   dataSource = new MatTableDataSource<any>([]);
   showReduntent: boolean = false;
   titlePage: any;
+  savePdf: EventEmitter<string> = new EventEmitter<string>();
   @ViewChild(MatPaginator) paginator: any;
 
   ngAfterViewInit() {
@@ -88,6 +89,10 @@ export class AcceleratedBreedingVersionComponent {
       name: 'description',
       content: `${this.sciencePrograms?.name} Version  `,
     });
+  }
+
+  exportLandscapePdf() {
+    this.savePdf.emit('landscape');
   }
 
   async export() {

--- a/front-end/src/app/home/risk-management/risk-report/risk-report-overview/risk-report-overview.component.html
+++ b/front-end/src/app/home/risk-management/risk-report/risk-report-overview/risk-report-overview.component.html
@@ -24,7 +24,8 @@
 
     <div class="risk-report-box">
       <div class="risk-report-title-box">
-        <h1 class="risk-report-title-box__title">Risk report</h1>
+        <h1 class="risk-report-title-box__title">{{ sciencePrograms?.name || 'Risk report' }}</h1>
+        <p class="risk-report-title-box__subtitle">Risk report</p>
         <div class="assign-org">
           <span *ngFor="let org of assignOrg; let last = last">
             {{ org.acronym }}<span *ngIf="!last">/</span><br />

--- a/front-end/src/app/home/risk-management/risk-report/risk-report-overview/risk-report-overview.component.scss
+++ b/front-end/src/app/home/risk-management/risk-report/risk-report-overview/risk-report-overview.component.scss
@@ -67,6 +67,14 @@
     line-height: normal;
   }
 
+  &__subtitle {
+    color: #5a6872;
+    font-family: "Poppins", sans-serif !important;
+    font-size: 1.6rem;
+    font-weight: 500;
+    margin-top: 0.4rem;
+  }
+
   .assign-org {
     display: flex;
     align-items: center;

--- a/front-end/src/app/home/risk-management/risk-report/risk-report-table/risk-report-table.component.ts
+++ b/front-end/src/app/home/risk-management/risk-report/risk-report-table/risk-report-table.component.ts
@@ -605,14 +605,17 @@ export class RiskReportTableComponent {
     }
 
     const programName  = this.sciencePrograms?.name || '';
-    const activePhase = await this.phasesService.getActivePhase();
-    const activePhaseYear = activePhase?.reporting_year || new Date().getFullYear();
+    const activePhaseYear = this.showingVersion && this.sciencePrograms?.phase?.reporting_year
+      ? this.sciencePrograms.phase.reporting_year
+      : (await this.phasesService.getActivePhase())?.reporting_year || new Date().getFullYear();
     cols = buildCols(activePhaseYear);
 
     const narrative = this.sciencePrograms?.narrative || '';
-    const progId = this.id || this.sciencePrograms?.id || '';
     const progCode = this.scienceProgramsId || this.sciencePrograms?.official_code || '';
-    const programLink = `${window.location.origin}/home/${progId}/${progCode}`;
+    const versionId = this.showingVersion
+      ? this.sciencePrograms?.id || ''
+      : this.sciencePrograms?.last_version_id || '';
+    const programLink = `${window.location.origin}/explore/${progCode}${versionId ? '/' + versionId : ''}`;
 
     // ── Header ──────────────────────────────────────────────────────────────
     // Row 1: Logo + "Top 5 submitted risks for {Year}" (left)  |  "Click here for more details" (right)

--- a/front-end/src/app/home/risk-management/risk-report/risk-report-table/risk-report-table.component.ts
+++ b/front-end/src/app/home/risk-management/risk-report/risk-report-table/risk-report-table.component.ts
@@ -610,7 +610,9 @@ export class RiskReportTableComponent {
     cols = buildCols(activePhaseYear);
 
     const narrative = this.sciencePrograms?.narrative || '';
-    const programLink = `${window.location.origin}/home/${this.id}/${this.scienceProgramsId}`;
+    const progId = this.id || this.sciencePrograms?.id || '';
+    const progCode = this.scienceProgramsId || this.sciencePrograms?.official_code || '';
+    const programLink = `${window.location.origin}/home/${progId}/${progCode}`;
 
     // ── Header ──────────────────────────────────────────────────────────────
     // Row 1: Logo + "Top 5 submitted risks for {Year}" (left)  |  "Click here for more details" (right)
@@ -794,7 +796,7 @@ export class RiskReportTableComponent {
       y += rowH;
     });
 
-    doc.save(`Risk-Report-Landscape-${this.scienceProgramsId}.pdf`);
+    doc.save(`Risk-Report-Landscape-${progCode}.pdf`);
   }
 
   private drawBarChart(

--- a/front-end/src/app/shared-services/explore-services/api-explore.service.ts
+++ b/front-end/src/app/shared-services/explore-services/api-explore.service.ts
@@ -1,0 +1,121 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { MainService } from 'src/app/services/main.service';
+
+export interface ExploreProgram {
+  id: number;
+  official_code: string;
+  name: string;
+  risk_count: number;
+  total_actions: number;
+  avg_current_level: number;
+  avg_target_level: number;
+  organizations?: ExploreOrganization[];
+}
+
+export interface ExploreOrganization {
+  id: number;
+  name: string;
+  acronym?: string;
+}
+
+export interface ExploreRisk {
+  id: number;
+  title: string;
+  description: string;
+  current_likelihood: number;
+  current_impact: number;
+  target_likelihood: number;
+  target_impact: number;
+  due_date: string;
+  category?: {
+    id: number;
+    title: string;
+    category_group?: {
+      id: number;
+      name: string;
+    };
+  };
+  risk_owner?: {
+    user?: {
+      full_name: string;
+      email: string;
+    };
+    email?: string;
+  };
+  mitigations?: ExploreMitigation[];
+}
+
+export interface ExploreMitigation {
+  id: number;
+  description: string;
+  status?: {
+    id: number;
+    title: string;
+  };
+}
+
+export interface ExploreProgramDetail {
+  id: number;
+  official_code: string;
+  name: string;
+  status: boolean;
+  narrative?: string;
+  phase?: { id: number; name: string };
+  organizations?: ExploreOrganization[];
+  roles?: ExploreProgramRole[];
+  risks?: ExploreRisk[];
+}
+
+export interface ExploreProgramRole {
+  id: number;
+  role: string;
+  user?: {
+    full_name: string;
+    email: string;
+  };
+  email?: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiExploreService extends MainService {
+  constructor(private http: HttpClient) {
+    super();
+  }
+
+  /**
+   * Retrieves all programs visible on the public explore page.
+   * @param search Optional search term to filter by name or code
+   */
+  getPrograms(search?: string): Observable<ExploreProgram[]> {
+    const params: any = {};
+    if (search && search.trim()) {
+      params['search'] = search.trim();
+    }
+    return this.http
+      .get<ExploreProgram[]>(this.backend_url + '/explore/programs', {
+        params,
+        headers: this.headers,
+      })
+      .pipe(map((d: any) => d));
+  }
+
+  /**
+   * Retrieves the latest submitted version detail for a single program.
+   * @param official_code The official code of the program (e.g. "INIT-01")
+   */
+  getProgramByCode(official_code: string): Observable<ExploreProgramDetail> {
+    return this.http
+      .get<ExploreProgramDetail>(
+        this.backend_url + '/explore/programs/' + official_code,
+        {
+          headers: this.headers,
+        }
+      )
+      .pipe(map((d: any) => d));
+  }
+}

--- a/front-end/src/app/shared-services/explore-services/api-explore.service.ts
+++ b/front-end/src/app/shared-services/explore-services/api-explore.service.ts
@@ -108,14 +108,13 @@ export class ApiExploreService extends MainService {
    * Retrieves the latest submitted version detail for a single program.
    * @param official_code The official code of the program (e.g. "INIT-01")
    */
-  getProgramByCode(official_code: string): Observable<ExploreProgramDetail> {
+  getProgramByCode(official_code: string, version_id?: string): Observable<ExploreProgramDetail> {
+    let url = this.backend_url + '/explore/programs/' + official_code;
+    if (version_id) {
+      url += '/' + version_id;
+    }
     return this.http
-      .get<ExploreProgramDetail>(
-        this.backend_url + '/explore/programs/' + official_code,
-        {
-          headers: this.headers,
-        }
-      )
+      .get<ExploreProgramDetail>(url, { headers: this.headers })
       .pipe(map((d: any) => d));
   }
 }


### PR DESCRIPTION
## Summary
- Add public Explore page (`/explore`) for browsing program risk reports without authentication
- Explore list: searchable table with avg current/target risk scores, total actions, risk count
- Explore view: program header, summary cards, pie charts (category + action status), expandable risk panels with mitigations
- Support version-specific URLs: `/explore/:code/:version_id`
- PDF landscape export "Click here" link now points to public explore page
- PDF uses version's phase reporting year when exporting from submitted versions

## Test plan
- [ ] Visit `/explore` — verify program list loads with scores and filters
- [ ] Click a program — verify risk details, charts, and mitigations display correctly
- [ ] Visit `/explore/SP01/146` — verify specific version loads
- [ ] Visit `/explore/SP01` — verify latest version loads
- [ ] Export landscape PDF from a submitted version — verify link points to `/explore/:code/:version_id`
- [ ] Export landscape PDF from main risk report — verify link uses latest version
- [ ] Verify PDF year matches the version's phase reporting year